### PR TITLE
Use Python virtual env in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,15 @@ jobs:
       - run: gcloud components update
       - <<: *install_postgres
       # install deps locally to enable unit testing
+      - run:
+          name: Create Python virtual env for use with all commands
+          command: |
+            python3 -m venv venv
+            echo "source $(pwd)/venv/bin/activate" >> $BASH_ENV
       - run: curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-      - run: sudo python3 get-pip.py
-      - run: sudo pip install -r ${SERVER_CODE_ROOT}/src/requirements.txt
-      - run: sudo pip install -r ${SERVER_CODE_ROOT}/dev_requirements.txt
+      - run: python3 get-pip.py
+      - run: pip install -r ${SERVER_CODE_ROOT}/src/requirements.txt
+      - run: pip install -r ${SERVER_CODE_ROOT}/dev_requirements.txt
       # Retrieve our secrets from the CircleCI environment
       - run: echo $APP_YML_BASE64 | base64 --decode > ${SERVER_SRC_ROOT}/config/app.yml
       - run: echo $CLIENT_SECRETS_BASE64 | base64 --decode > ${SERVER_SRC_ROOT}/config/client_secrets.json


### PR DESCRIPTION
fixes this build error:

```
Installing collected packages: validate-email, PyJWT, pyasn1, oauthlib, zipp, Werkzeug, uritemplate, sentry-sdk, rsa, PyYAML, python-dateutil, pyparsing, pyasn1-modules, psycopg2-binary, MarkupSafe, itsdangerous, gunicorn, greenlet, decorator, click, cachetools, blinker, WTForms, validators, SQLAlchemy, Mako, jinja2, importlib-resources, importlib-metadata, httplib2, google-auth, oauth2client, google_auth_httplib2, Flask, alembic, google_api_python_client, Flask-WTF, Flask-SQLAlchemy, Flask-Login, Flask-Migrate
  Attempting uninstall: PyYAML
    Found existing installation: PyYAML 5.3.1
ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```