### PR TITLE
Add tests for conflicting programmatic links, fix conflicting links validation

### DIFF
--- a/server/src/modules/links/helpers.py
+++ b/server/src/modules/links/helpers.py
@@ -121,15 +121,17 @@ def find_conflicting_link(organization, namespace, shortpath):
 
   for link in links_with_prefix:
     other_shortpath_parts = link.shortpath.split('/')
-
     if len(shortpath_parts) != len(other_shortpath_parts):
       continue
-
+    
+    found_conflicting_part = False
     for i in range(0, len(shortpath_parts)):
       if shortpath_parts[i] != '%s' and shortpath_parts[i] != other_shortpath_parts[i]:
-        continue
+        found_conflicting_part = True
+        break
 
-    return link
+    if not found_conflicting_part:
+      return link
 
   return None
 

--- a/server/src/testing/__init__.py
+++ b/server/src/testing/__init__.py
@@ -11,9 +11,9 @@ import yaml
 
 import main
 
+multiprocessing.set_start_method('fork')
 
 LIVE_APP_HOST = 'http://localhost:5010'
-
 
 class TrottoTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Fixes https://github.com/trotto/go-links/issues/164

Adds the test to ensure we can create programmatic links that match the first segments but not all. 
Fixes the validation to correctly flag when links are the same.