### PR TITLE
Add support for org validation regex config

### DIFF
--- a/frontend/src/actions.js
+++ b/frontend/src/actions.js
@@ -3,7 +3,7 @@ import { browserHistory } from 'react-router';
 import fetch from 'isomorphic-fetch'
 import { DEFAULT_NAMESPACE } from './config';
 import {getServiceBaseUrl} from './utils';
-
+import { keywordsValidationRegex } from './getters';
 
 const enhancedFetch = function(endpoint, fetchInit, dispatch) {
 
@@ -37,19 +37,23 @@ export function setErrorBarMessage(errorMessage) {
 }
 
 
-export function updateNewLinkField(fieldName, elem) {
-  var fieldValue = elem.target.value.trim().replace(' ', '');
-  if (fieldName == 'shortpath') {
-    fieldValue = fieldValue.replace(/[^0-9a-zA-Z\-\/%]/g, '').toLowerCase();
-    while (fieldValue[0] === '/') {
-      fieldValue = fieldValue.slice(1)
+export function updateNewLinkField(fieldName, elem ) {
+  return function(dispatch, getState){
+    var fieldValue = elem.target.value.trim().replace(' ', '');
+    const validationRegex = keywordsValidationRegex(getState().core) ?? '[^0-9a-zA-Z\-\/%]';
+        
+    if (fieldName == 'shortpath') {
+      fieldValue = fieldValue.replace(new RegExp(validationRegex,'g'), '').toLowerCase();
+      while (fieldValue[0] === '/') {
+        fieldValue = fieldValue.slice(1)
+      }
     }
-  }
 
-  return {
-    type: 'UPDATE_NEW_LINK_FIELD',
-    fieldName,
-    fieldValue
+    return dispatch({
+      type: 'UPDATE_NEW_LINK_FIELD',
+      fieldName,
+      fieldValue
+    })
   }
 }
 

--- a/frontend/src/getters.js
+++ b/frontend/src/getters.js
@@ -21,11 +21,11 @@ export const readOnlyMode = createSelector(
     }
 );
 
-  export const keywordsValidationRegex = createSelector(
-    userInfo,
-    (userInfo) => {
-      return userInfo && userInfo.get('keywords_validation_regex');
-    }
+export const keywordsValidationRegex = createSelector(
+  userInfo,
+  (userInfo) => {
+    return userInfo && userInfo.get('keywords_validation_regex');
+  }
 );
 
 

--- a/frontend/src/getters.js
+++ b/frontend/src/getters.js
@@ -21,6 +21,13 @@ export const readOnlyMode = createSelector(
     }
 );
 
+  export const keywordsValidationRegex = createSelector(
+    userInfo,
+    (userInfo) => {
+      return userInfo && userInfo.get('keywords_validation_regex');
+    }
+);
+
 
 export const linksById = createSelector(
     links,

--- a/server/src/modules/links/helpers.py
+++ b/server/src/modules/links/helpers.py
@@ -170,9 +170,9 @@ KEYWORDS_PUNCTUATION_SENSITIVE_DEFAULT = True
 ALTERNATIVE_KEYWORD_RESOLUTION_MODE = 'alternative'
 
 
-def validate_shortpath(shortpath, validation_mode):
+def validate_shortpath(shortpath, validation_mode, validation_regex = '[^0-9a-zA-Z\-\/%]'):
   if validation_mode == SIMPLE_VALIDATION_MODE:
-    if shortpath != re.sub('[^0-9a-zA-Z\-\/%]', '', shortpath):
+    if shortpath != re.sub(validation_regex, '', shortpath):
       raise LinkCreationException(PATH_RESTRICTIONS_ERROR_SIMPLE)
   elif validation_mode == EXPANDED_VALIDATION_MODE:
     if type(validators.url('https://trot.to/'+shortpath)) is ValidationFailure:

--- a/server/src/modules/links/helpers.py
+++ b/server/src/modules/links/helpers.py
@@ -172,8 +172,12 @@ ALTERNATIVE_KEYWORD_RESOLUTION_MODE = 'alternative'
 DEFAULT_VALIDATION_REGEX = '[^0-9a-zA-Z\-\/%]'
 
 
+def get_keyword_validation_regex(org_settings):
+  return get_from_key_path(org_settings or {}, ['keywords', 'validation_regex']) or DEFAULT_VALIDATION_REGEX
+
+
 def validate_shortpath(organization, shortpath, validation_mode):
-  validation_regex = get_from_key_path(config.get_organization_config(organization), ['keywords', 'validation_regex']) or DEFAULT_VALIDATION_REGEX
+  validation_regex = get_keyword_validation_regex(config.get_organization_config(organization))
 
   if validation_mode == SIMPLE_VALIDATION_MODE:
     if shortpath != re.sub(validation_regex, '', shortpath):

--- a/server/src/modules/links/helpers.py
+++ b/server/src/modules/links/helpers.py
@@ -11,6 +11,7 @@ from modules.organizations.utils import get_organization_id_for_email
 from shared_helpers import config
 from shared_helpers.encoding import convert_entity_to_dict
 from shared_helpers.events import enqueue_event
+from shared_helpers.utils import get_from_key_path
 
 
 models = get_models('links')
@@ -168,9 +169,12 @@ PATH_RESTRICTIONS_ERROR_SIMPLE = 'Keywords can include only letters, numbers, hy
 PATH_RESTRICTIONS_ERROR_EXPANDED = 'Provided keyword is invalid' # TODO: Include invalid char(s) in error
 KEYWORDS_PUNCTUATION_SENSITIVE_DEFAULT = True
 ALTERNATIVE_KEYWORD_RESOLUTION_MODE = 'alternative'
+DEFAULT_VALIDATION_REGEX = '[^0-9a-zA-Z\-\/%]'
 
 
-def validate_shortpath(shortpath, validation_mode, validation_regex = '[^0-9a-zA-Z\-\/%]'):
+def validate_shortpath(organization, shortpath, validation_mode):
+  validation_regex = get_from_key_path(config.get_organization_config(organization), ['keywords', 'validation_regex']) or DEFAULT_VALIDATION_REGEX
+
   if validation_mode == SIMPLE_VALIDATION_MODE:
     if shortpath != re.sub(validation_regex, '', shortpath):
       raise LinkCreationException(PATH_RESTRICTIONS_ERROR_SIMPLE)
@@ -246,7 +250,7 @@ def upsert_short_link(acting_user, organization, owner, namespace, shortpath, de
   if not shortpath:
     raise LinkCreationException('You must provide a path')
 
-  validate_shortpath(shortpath, validation_mode)
+  validate_shortpath(organization, shortpath, validation_mode)
 
   display_shortpath = shortpath
   org_config = config.get_organization_config(organization)

--- a/server/src/modules/users/handlers.py
+++ b/server/src/modules/users/handlers.py
@@ -3,6 +3,7 @@ import copy
 from flask import Blueprint, request, jsonify, abort
 from flask_login import current_user, login_required
 
+from modules.links.helpers import get_keyword_validation_regex
 from modules.organizations.helpers import get_org_edit_mode
 from modules.users.helpers import get_users_by_organization, is_user_admin, get_user_by_id, get_admin_ids
 from shared_helpers.config import get_organization_config
@@ -27,7 +28,7 @@ def _user_info(user, admins_ids=None, org_edit_mode=None, org_settings=None):
     user_info.update({
       'read_only_mode': org_settings.get('read_only_mode'),
       'info_bar': org_settings.get('info_bar'),
-      'keywords_validation_regex': org_settings.get('keywords').get('validation_regex'),
+      'keywords_validation_regex': get_keyword_validation_regex(org_settings)
     })
 
   if org_edit_mode:

--- a/server/src/modules/users/handlers.py
+++ b/server/src/modules/users/handlers.py
@@ -26,7 +26,8 @@ def _user_info(user, admins_ids=None, org_edit_mode=None, org_settings=None):
   if org_settings is not None:
     user_info.update({
       'read_only_mode': org_settings.get('read_only_mode'),
-      'info_bar': org_settings.get('info_bar')
+      'info_bar': org_settings.get('info_bar'),
+      'keywords_validation_regex': org_settings.get('keywords').get('validation_regex'),
     })
 
   if org_edit_mode:

--- a/server/src/modules/users/tests/handlers_tests.py
+++ b/server/src/modules/users/tests/handlers_tests.py
@@ -52,7 +52,8 @@ class TestUserHandlers(TrottoTestCase):
                       'notifications': {'some_announcement': 'dismissed'},
                       'org_edit_mode': 'owners_and_admins_only',
                       'read_only_mode': None,
-                      'info_bar': None})
+                      'info_bar': None,
+                      'keywords_validation_regex': '[^0-9a-zA-Z\\-\\/%]'})
 
     response = self.testapp.get('/_/api/users/me',
                                 headers={'TROTTO_USER_UNDER_TEST': 'ray@googs.com'})


### PR DESCRIPTION
# Description
This PR enables the customization of the validation regex for organizations. 

Example for allowing Japanese characters: 
```yaml
keywords: 
  validation_regex: '[^一-龠ぁ-ゔァ-ヴーa-zA-Z0-9ａ-ｚＡ-Ｚ０-９々〆〤\-\/%]'
```
