### PR TITLE
Updated pyjwt 1.7.1 -> 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-Login==0.6.2
 Flask-SQLAlchemy===2.4.1
 Flask-WTF==0.14.3
 Werkzeug==2.0.3
-PyJWT==1.7.1
+PyJWT==2.4.0
 PyYAML==5.4
 sentry-sdk[flask]==0.20.3
 validate-email==1.3

--- a/server/src/modules/base/tests/handlers_tests.py
+++ b/server/src/modules/base/tests/handlers_tests.py
@@ -132,7 +132,7 @@ class TestHandlers(AuthenticationTestCase):
   def test_login_via_test_token__invalid_token(self, _):
     token = jwt.encode({'email': 'sam@example.com'}, 'some_secret', algorithm='HS256')
 
-    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token.decode("utf-8")}',
+    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token}',
                                 expect_errors=True)
 
     self.assertEqual(500, response.status_int)
@@ -143,7 +143,7 @@ class TestHandlers(AuthenticationTestCase):
   def test_login_via_test_token__no_test_token_config(self, _):
     token = jwt.encode({'email': 'sam@example.com'}, 'a_test_secret', algorithm='HS256')
 
-    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token.decode("utf-8")}',
+    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token}',
                                 expect_errors=True)
 
     self.assertEqual(500, response.status_int)
@@ -155,7 +155,7 @@ class TestHandlers(AuthenticationTestCase):
   def test_login_via_test_token__valid_token_invalid_domain(self, _):
     token = jwt.encode({'user_email': 'sam@googs.com'}, 'a_test_secret', algorithm='HS256')
 
-    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token.decode("utf-8")}',
+    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token}',
                                 expect_errors=True)
 
     self.assertEqual(500, response.status_int)
@@ -167,7 +167,7 @@ class TestHandlers(AuthenticationTestCase):
   def test_login_via_test_token__success(self, _):
     token = jwt.encode({'user_email': 'sam@example.com'}, 'a_test_secret', algorithm='HS256')
 
-    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token.decode("utf-8")}')
+    response = self.testapp.get(f'/_/auth/oauth2_callback?test_token={token}')
 
     self.assertEqual(302, response.status_int)
 
@@ -188,7 +188,7 @@ def _generate_signin_token(secret, org, expires_in_seconds, user_id=None, user_e
 
   return jwt.encode(payload,
                     secret,
-                    'HS256').decode('utf-8')
+                    'HS256')
 
 class TestAuthenticationControls(AuthenticationTestCase):
 

--- a/server/src/modules/links/handlers.py
+++ b/server/src/modules/links/handlers.py
@@ -181,7 +181,7 @@ def create_transfer_link(link_id):
              'o': user_helpers.get_or_create_user(g.link.owner, g.link.organization).id,  # "o" -> link owner
              'by': current_user.id}
 
-  token = jwt.encode(payload, config.get_config()['sessions_secret'], algorithm='HS256')
+  token = jwt.encode(payload, config.get_config()['sessions_secret'], algorithm='HS256').encode('utf-8')
 
   full_url = f"{request.host_url}_transfer/{base64.urlsafe_b64encode(token).decode('utf-8').strip('=')}"
 

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -13,7 +13,7 @@ Flask-Login==0.6.2
 Flask-SQLAlchemy===2.4.1
 Flask-WTF==0.14.3
 Werkzeug==2.0.3
-PyJWT==1.7.1
+PyJWT==2.4.0
 PyYAML==5.4
 sentry-sdk[flask]==0.20.3
 validate-email==1.3


### PR DESCRIPTION
In PyJWT 2+ was changed result of pyjwt.encode(...), now it returns `str` instead of `bytes`, since that I fixed all places where it was called.