### PR TITLE
Fixed SQLAlchemy version to 1.4.46

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ Werkzeug==2.0.3
 PyJWT==2.4.0
 PyYAML==5.4
 sentry-sdk[flask]==0.20.3
+SQLAlchemy==1.4.46
 validate-email==1.3
 validators==0.18.2

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -17,5 +17,6 @@ Werkzeug==2.0.3
 PyJWT==2.4.0
 PyYAML==5.4
 sentry-sdk[flask]==0.20.3
+SQLAlchemy==1.4.46
 validate-email==1.3
 validators==0.18.2


### PR DESCRIPTION
#### Description

Fixed sqlalchemy to 1.4.46 as later 2.0.0 release breaks the app

---

##### 🔬 How to test

- pip install -r requirements.txt
- run the app

##### 📸 Cypress Screenshots _(if applicable)_

---

##### Changes include

- [ ] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
