### PR TITLE
Revert "Bump flask from 2.0.3 to 2.3.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ oauthlib==2.0.6
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1
 requests==2.22.0
-Flask==2.3.2
+Flask==2.0.3
 Flask-Migrate==3.1.0
 Flask-Login==0.6.2
 Flask-SQLAlchemy===2.4.1


### PR DESCRIPTION
Reverts trotto/go-links#215