### PR TITLE
Upgraded PyYAML to 6.0.1 as previous versions are incompatible viwh new Cython release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Flask-WTF==0.14.3
 launchdarkly-server-sdk==8.0.0
 Werkzeug==2.0.3
 PyJWT==2.4.0
-PyYAML==5.4
+PyYAML==6.0.1
 sentry-sdk[flask]==0.20.3
 SQLAlchemy==1.4.46
 validate-email==1.3

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -16,7 +16,7 @@ Flask-WTF==0.14.3
 launchdarkly-server-sdk==8.0.0
 Werkzeug==2.0.3
 PyJWT==2.4.0
-PyYAML==5.4
+PyYAML==6.0.1
 sentry-sdk[flask]==0.20.3
 SQLAlchemy==1.4.46
 validate-email==1.3


### PR DESCRIPTION
#### Description

Fix for issue https://github.com/trotto/go-links/issues/228

---

##### 🔬 How to test
```
docker build -t trotto .
```

Upgrade was verified with unit tests and manually

##### 📸 Cypress Screenshots _(if applicable)_

---

##### Changes include

- [x] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
