### PR TITLE
Fix dyno size in Heroku manifest

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "hobby"
+      "size": "basic"
     }
   },
   "addons": [


### PR DESCRIPTION
#### Description

The `hobby` size is obsolete. See https://devcenter.heroku.com/articles/app-json-schema#formation.

##### 🔬 How to test

Deploy a Heroku app from the `jon.heroku_fix` branch: https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2F&template=https%3A%2F%2Fgithub.com%2Ftrotto%2Fgo-links/tree/jon.heroku_fix

##### Changes include

- [x] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
