### PR TITLE
Added support for limiting auth to a specific domain

### DIFF
--- a/server/src/modules/base/handlers.py
+++ b/server/src/modules/base/handlers.py
@@ -40,7 +40,12 @@ def get_google_login_url(oauth_redirect_uri=None, redirect_to_after_oauth=None):
 
   session['oauth_state'] = utils.generate_secret(32)
   try:
-    return str(flow.step1_get_authorize_url(state=session['oauth_state']))
+    url = str(flow.step1_get_authorize_url(state=session["oauth_state"]))
+    hosted_domain = get_config().get('google_auth_hosted_domain', None)
+    if hosted_domain:
+      return f'{url}&hd={hosted_domain}'
+    else:
+      return url
   except TypeError:
     # TODO: Fix breakage only appearing in tests.
     return str(flow.step1_get_authorize_url())

--- a/server/src/shared_helpers/config.py
+++ b/server/src/shared_helpers/config.py
@@ -25,8 +25,13 @@ def get_config():
     return yaml.load(base64.b64decode(os.getenv('TROTTO_CONFIG')), Loader=yaml.SafeLoader)
 
   if os.getenv('DATABASE_URL') and os.getenv('FLASK_SECRET'):
-    return {'postgres': {'url': os.getenv('DATABASE_URL')},
-            'sessions_secret': os.getenv('FLASK_SECRET')}
+    return {
+      'postgres': {
+        'url': os.getenv('DATABASE_URL')
+      },
+      'sessions_secret': os.getenv('FLASK_SECRET'),
+      'google_auth_hosted_domain': os.getenv('GOOGLE_AUTH_HOSTED_DOMAIN') or None
+    }
 
   config_file_name = 'secrets.yaml'
 


### PR DESCRIPTION


#### Description

This change allows Google Auth to only function for the given domain, further ensuring that external users cannot gain access.

---

##### 🔬 How to test

1. Set the `GOOGLE_AUTH_HOSTED_DOMAIN` to a domain.
2. Attempt to sign in.
3. Confirm that sign in is only allowed for users of the specified domain.

---

##### Changes include

- [ ] Bug fix (_non-breaking change that solves an issue_)
- [x] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
