### PR TITLE
Fixed pool_pre_ping configuration

### DIFF
--- a/server/src/db.py
+++ b/server/src/db.py
@@ -1,8 +1,3 @@
-from flask_sqlalchemy import SQLAlchemy as _BaseSQLAlchemy
-
-class SQLAlchemy(_BaseSQLAlchemy):
-  def apply_pool_defaults(self, app, options):
-    super(SQLAlchemy, self).apply_pool_defaults(app, options)
-    options["pool_pre_ping"] = True
+from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -46,6 +46,10 @@ def init_app_without_routes(disable_csrf=False):
   app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
   app.config['SESSION_COOKIE_SECURE'] = True
 
+  app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+    'pool_pre_ping': True
+  }
+
   from modules.base import authentication
 
   if os.getenv('ENVIRONMENT') == 'test_env':
@@ -175,7 +179,7 @@ def home():
 
   if feature_flags.provider.get('new_frontend', current_user):
     return render_template('_next_static/index.html')
-  
+
   nonce = os.urandom(16).hex()
 
   response = render_template('index.html',


### PR DESCRIPTION


#### Description

apply_pool_defaults was removed in flask-sqlalchemy 3.x. `SQLALCHEMY_ENGINE_OPTIONS` is used to enable pool_pre_ping, and avoid 500 errors if the database connection during a pronlonged period between requests.

---

##### 🔬 How to test

1. Run the service.
2. Close the database connection between the service and the DB server.
3. Navigate to a go link.
4. Confirm the redirect works as expected (and no server error is thrown).

##### Changes include

- [x] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
